### PR TITLE
Corrections and adjustments in grammar (Croatian language)

### DIFF
--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -865,9 +865,9 @@
     'and': 'i',
     'in': 'u',
     'ago': 'prije',
-    'now': 'sad',
+    'now': 'sada',
     'lose': 'gubiš',
-    'gain': 'dobijaš',
+    'gain': 'dobivaš',
     'time':{
       'format': '24-hr',
       'year': [
@@ -905,8 +905,8 @@
       'today': 'danas',
       'tomorrow': 'sutra',
       'yesterday': 'jučer',
-      'next': 'slijedeći',
-      'last': 'prošli',
+      'next': 'sljedeći',
+      'last': 'protekli',
     },
     'days':[
       "Ponedjeljak",


### PR DESCRIPTION
**LOG:**
The word "prošli" has been substituted with "protekli" which is considered more grammatically accurate.
The word "dobijaš" has been substituted with "dobivaš" which is regarded as more grammatically accurate and standard rather than dialectical.
The word "slijedeći" has been changed to "sljedeći" as "slijedeći" implies following someone rather than indicating what is upcoming or next.
The word "sad" has been replaced with "sada" for better grammatical precision.