### PR TITLE
weekday function - removed positive restriction

### DIFF
--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -1541,7 +1541,7 @@
 {%- macro weekday(weekday=None, language=None) %}
 {%- if weekday is datetime %}
 {%- set idx = weekday.weekday() %}
-{%- elif weekday is integer and weekday > 0 %}
+{%- elif weekday is integer %}
 {%- set idx = (weekday - 1) % 7 %}
 {%- else %}
 {%- set idx = now().weekday() %}


### PR DESCRIPTION
Removed the positive restriction for the weekday parameter, because the algorithm is still correct, and it would make the speak_the_days() function return today's name for most negative indexes (i <= -2).