### PR TITLE
_relative_time() macro - ZeroDivisonError fix for current time

### DIFF
--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -1320,9 +1320,12 @@
 {%- if uptime %}
   {%- set value = _delta_seconds(now(), uptime) | int %}
   {%- set seconds = value | abs %}
-  {%- set future = value / seconds > 0 %}
+  {%- set now = value == 0 %}
+  {%- set future = not now and value / seconds > 0 %}
   {%- set items = _just_time(seconds, language, values, biggest, short=short, floor=floor) %}
-  {%- if future %}
+  {%- if now %}
+    {{- items }}
+  {%- elif future %}
     {{- translate('in', language=language) }} {{ items }}
   {%- else %}
     {%- set t = translate('ago', language=language) %}


### PR DESCRIPTION
For the current time, the `_delta_seconds()` returns zero, which is then used to determine whether the time is in the future using a division and that threw a `ZeroDivisonError` (and stopped the template from updating). This was especially frustrating if you used the `easy_relative_time()` macro for frequently changing times (like the `last_updated` attribute of an entity). You can easily test this PR for yourself with:
```
{% from 'easy_time.jinja' import easy_relative_time %}
{{ easy_relative_time(now()) }}
```