### PR TITLE
add Nl translations to time_of_hour and time_of_day

### DIFF
--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -226,7 +226,21 @@
       'oktober',
       'november',
       'december',
-    ]
+    ],
+    'time_of_hour':{
+      0: 'klokslag {hour} uur',
+      1: 'een minuut over {hour}',
+      15: 'kwart over {hour}',
+      30: 'half {hour + 1}',
+      45: 'kwart voor {hour}',
+      59: 'een minuut voor {hour}',
+      'past_hour': '{minute} na {hour}',
+      'to_hour': '{minute} voor {hour}', 
+    },
+    'time_of_day':{
+      'midnight': 'middernacht',
+      'noon': 'middag',
+    },
   },
   'sv':{
     '_language': 'Svenska',


### PR DESCRIPTION
need to check 'half past {hour}'

because in Dutch we add to the next hour and say
'half 9' in stead of 'half past 8'

