### PR TITLE
Making the clock_phrase macro more versatile.

### DIFF
--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -242,8 +242,6 @@
   
     },
     'time_of_day':{
-      'midnightx': '12 middernacht',
-      'noonx': '12 \'s middags',
     },
   },
   'sv':{

--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -76,10 +76,10 @@
       1: 'a minute past {hour}',
       15: 'quarter past {hour}',
       30: 'half past {hour}',
-      45: 'quarter to {hour}',
-      59: 'a minute to {hour}',
+      45: ['quarter to {hour}',1],
+      59: ['a minute to {hour}',1],
       'past_hour': '{minute} past {hour}',
-      'to_hour': '{minute} to {hour}', 
+      'to_hour': ['{minute} to {hour}',1,-60], 
     },
     'time_of_day':{
       'midnight': 'midnight',
@@ -724,10 +724,10 @@
       1: '{hour} y un minuto',
       15: '{hour} y quarto',
       30: '{hour} y media',
-      45: '{hour} menos quarto',
-      59: '{hour} menos uno',
+      45: ['{hour} menos quarto', 1],
+      59: ['{hour} menos uno', 1],
       'past_hour': '{hour} y {minute}',
-      'to_hour': '{hour} menos {minute}', 
+      'to_hour': ['{hour} menos {minute}', 1], 
     },
     'time_of_day':{
       'midnight': 'medianoche',
@@ -1096,10 +1096,10 @@
       1: '{hour} и 1 минута',
       15: '{hour} с четвертью',
       30: '{hour} с половиной',
-      45: 'без четверти {hour}',
-      59: 'без минуты {hour}',
+      45: ['без четверти {hour}', 1],
+      59: 'без минуты {hour}', 1],
       'past_hour': '{hour} и {minute} минут',
-      'to_hour': 'без {minute} минут {hour}', 
+      'to_hour': ['без {minute} минут {hour}', 1], 
     },
     'time_of_day':{
       'midnight': 'полночь',
@@ -1720,24 +1720,38 @@
 {%- endif %}
 {%- set this_hour = dt.hour %}
 {%- set this_minute = dt.minute %}
-{%- if this_minute > 30 %}
-  {%- set hour_phrase = hour(this_hour + 1, language=language) %}
-  {%- set minute_calc = 60 - this_minute %}
-  {%- set minute_phrase = _phrase('minute', 60 * minute_calc, language, True, True) if this_minute % 5 else minute_calc | string %}
-{%- else %}
-  {%- set hour_phrase = hour(this_hour, language=language) %}
-  {%- set minute_phrase = _phrase('minute', 60 * this_minute, language, True, True) if this_minute % 5 else this_minute | string %}
-{%- endif %}
-{%- if this_minute in [0, 1, 15, 30, 45, 59] %}
-  {%- if hour_phrase in ['noon', 'midnight'] and this_minute == 0 %}
-    {%- set fmat = '{hour}' %}
-  {%- else %}
-    {%- set fmat = translate('time_of_hour', this_minute, language=language) %}
+{%- set fmat = translate('time_of_hour', this_minute, language=language) %}
+
+{%- if fmat is none and this_minute >= 30 %}
+  {%- if this_minute <= 45 %}
+    {%- set fmat = translate('time_of_hour', 'past_half_hour', language=language) %}
   {%- endif %}
-{%- elif this_minute > 30 %}
-  {%- set fmat = translate('time_of_hour', 'to_hour', language=language) %}
-{%- else %}
+  {%- if fmat is none %}
+    {%- set fmat = translate('time_of_hour', 'to_hour', language=language) %}
+  {%- endif %}
+{%- endif %}
+
+{%- if fmat is none and this_minute < 30 and this_minute >= 15 %}
+  {%- set fmat = translate('time_of_hour', 'to_half_hour', language=language) %}
+{%- endif %}
+
+{%- if fmat is none %}
   {%- set fmat = translate('time_of_hour', 'past_hour', language=language) %}
+{%- endif %}
+
+{%- if fmat is string() %}
+  {%- if fmat[1] is number %}
+      {%- set this_hour = this_hour + fmat[1]  %}
+  {%- endif %}
+  {%- if fmat[2] is number %}
+      {%- set this_minute = this_minute + fmat[2]|abs  %}
+  {%- endif %}
+   {%- set fmat = fmat[0] %}
+{%- endif %}
+{%- set hour_phrase = hour(this_hour, language=language) %}
+{%- set minute_phrase = _phrase('minute', 60 * this_minute, language, True, True) if this_minute % 5 else this_minute | string %}
+{%- if hour_phrase in ['noon', 'midnight'] and this_minute == 0 %}
+   {%- set fmat = '{hour}' %}
 {%- endif %}
 {{- fmat.format(hour=hour_phrase, minute=minute_phrase) -}}
 {%- endmacro %}

--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -1,4 +1,4 @@
-{%- set default_language = 'en' %}
+{%- set default_language = 'en' -%}
 {%- set languages = {
   'en':{
     '_language': 'English',
@@ -84,7 +84,7 @@
     'time_of_day':{
       'midnight': 'midnight',
       'noon': 'noon',
-    },
+    },  
   },
   'sk':{
     '_language': 'Slovak',
@@ -226,7 +226,25 @@
       'oktober',
       'november',
       'december',
-    ]
+    ],
+    'time_of_hour':{
+      0: '{hour} uur',
+      1: '1 over {hour}',
+      15: 'kwart over {hour}',
+      30: 'half {next_hour}',
+      45: 'kwart voor {next_hour}',
+      59: '1 voor {next_hour}',
+      'past_hour': '{this_minute} over {hour}',
+      'to_hour': '{minute_to_60} voor {next_hour}', 
+      'past_halfhour': '{minute_to_30} over half {next_hour}',
+      'to_halfhour': '{minute_to_30} voor half {next_hour}', 
+      'format': '12-hr',
+  
+    },
+    'time_of_day':{
+      'midnightx': '12 middernacht',
+      'noonx': '12 \'s middags',
+    },
   },
   'sv':{
     '_language': 'Svenska',
@@ -724,10 +742,10 @@
       1: '{hour} y un minuto',
       15: '{hour} y quarto',
       30: '{hour} y media',
-      45: ['{hour} menos quarto', 1],
-      59: ['{hour} menos uno', 1],
+      45: '{hour} menos quarto',
+      59: '{hour} menos uno',
       'past_hour': '{hour} y {minute}',
-      'to_hour': ['{hour} menos {minute}', 1], 
+      'to_hour': '{hour} menos {minute}', 
     },
     'time_of_day':{
       'midnight': 'medianoche',
@@ -1096,10 +1114,10 @@
       1: '{hour} и 1 минута',
       15: '{hour} с четвертью',
       30: '{hour} с половиной',
-      45: ['без четверти {hour}', 1],
-      59: 'без минуты {hour}', 1],
+      45: 'без четверти {hour}',
+      59: 'без минуты {hour}',
       'past_hour': '{hour} и {minute} минут',
-      'to_hour': ['без {minute} минут {hour}', 1], 
+      'to_hour': 'без {minute} минут {hour}', 
     },
     'time_of_day':{
       'midnight': 'полночь',
@@ -1692,7 +1710,7 @@
 {%- endif %}
 {%- endmacro %}
 
-{%- macro hour(hour, language=None) %}
+{% macro hour(hour, format=None, language=None) -%}
 {%- if hour is datetime %}
   {%- set hour = hour.hour %}
 {%- elif hour | regex_match(valid_entity_id_pattern) %}
@@ -1700,17 +1718,24 @@
 {%- endif %}
 {%- set _12 = not (hour % 12) %}
 {%- set _24 = not (hour % 24) %}
-{%- set _12hr = translate('time','format') == '12-hr' %}
-{%- if _12 and _24 and _12hr %}
-  {{- translate('time_of_day', 'midnight', language=language) }}
-{%- elif _12 and _12hr %}
-  {{- translate('time_of_day', 'noon', language=language) }}
+{%- if hour is datetime %}
+  {%- set format = translate('time','format') %}
+{%- endif %}
+{%- set is_12hr = format == '12-hr' %}
+{%- set hour = hour % 12 if is_12hr else hour % 24 %}
+{%- if hour == 0  %}
+  {%- set hour = 24 if (_24 and not is_12hr) else 12 %}
+{%- endif %}
+{%- if _24 and is_12hr %}
+  {{- translate('time_of_day', 'midnight',  fallback=hour,  language=language) }}
+{%- elif _12 and is_12hr %}
+  {{- translate('time_of_day', 'noon',  fallback=hour,  language=language) }}
 {%- else %}
-  {{- hour % 12 if _12hr else hour }}
+  {{- hour }}
 {%- endif %}
 {%- endmacro %}
 
-{%- macro clock_phrase(input=None, attr=None, utc=False, language=None) %}
+{% macro clock_phrase(input=None, attr=None, utc=False, language=None) -%}
 {%- if input is none %}
   {%- set dt = now() %}
 {%- elif input is datetime %}
@@ -1718,40 +1743,45 @@
 {%- else %}
   {%- set dt = _to_datetime(input, attr, utc) | as_datetime %}
 {%- endif %}
+{%- set format = translate('time_of_hour','format') %}
 {%- set this_hour = dt.hour %}
+{%- set this_hour_phrase = hour(this_hour, format=format, language=language) %}
+{%- set next_hour_phrase = hour(this_hour + 1, format=format, language=language) %}
 {%- set this_minute = dt.minute %}
-{%- set fmat = translate('time_of_hour', this_minute, language=language) %}
-
-{%- if fmat is none and this_minute >= 30 %}
-  {%- if this_minute <= 45 %}
-    {%- set fmat = translate('time_of_hour', 'past_half_hour', language=language) %}
+{%- set this_minute_phrase = this_minute | string %}
+{%- set minute_to_60 = 60 - this_minute %}
+{%- set minute_to_60_phrase = minute_to_60 | string %}
+{%- if this_minute > 15 and this_minute < 45 %}
+  {%- set minute_to_30 = 30 - this_minute %}
+  {%- if minute_to_30 < 0 %}
+    {%- set minute_to_30 = - minute_to_30 %}
   {%- endif %}
-  {%- if fmat is none %}
-    {%- set fmat = translate('time_of_hour', 'to_hour', language=language) %}
+  {%- set minute_to_30_phrase = minute_to_30 | string %}
+{%- else %}
+  {%- set minute_to_30_phrase = 'unknown' %}
+{%- endif %}
+{%- if this_minute > 30 %}
+  {%- set hour_phrase = next_hour_phrase %}
+  {%- set minute_calc = 60 - this_minute %}
+  {%- set minute_phrase = _phrase('minute', 60 * minute_calc, language, True, True) if this_minute % 5 else minute_calc | string %}
+{%- else %}
+  {%- set hour_phrase = this_hour_phrase %}
+  {%- set minute_phrase = _phrase('minute', 60 * this_minute, language, True, True) if this_minute % 5 else this_minute | string %}
+{%- endif %}
+{%- if (hour_phrase|float(-999) ==-999) and this_minute == 0 %}
+    {%- set fmat = '{hour}' %}
+{%- elif this_minute in [0, 1, 15, 30, 45, 59] %}
+    {%- set fmat = translate('time_of_hour', this_minute, language=language) %}
+{%- elif this_minute > 30 %}
+  {%- set fmat = translate('time_of_hour', 'to_hour', language=language) %}
+  {%- if this_minute < 45 %}
+    {%- set fmat = translate('time_of_hour', 'past_halfhour', fallback=fmat,  language=language) %}
   {%- endif %}
-{%- endif %}
-
-{%- if fmat is none and this_minute < 30 and this_minute >= 15 %}
-  {%- set fmat = translate('time_of_hour', 'to_half_hour', language=language) %}
-{%- endif %}
-
-{%- if fmat is none %}
+{%- else %}
   {%- set fmat = translate('time_of_hour', 'past_hour', language=language) %}
-{%- endif %}
-
-{%- if fmat is string() %}
-  {%- if fmat[1] is number %}
-      {%- set this_hour = this_hour + fmat[1]  %}
+  {%- if this_minute > 15 %}
+    {%- set fmat = translate('time_of_hour', 'to_halfhour', fallback=fmat,  language=language) %}
   {%- endif %}
-  {%- if fmat[2] is number %}
-      {%- set this_minute = this_minute + fmat[2]|abs  %}
-  {%- endif %}
-   {%- set fmat = fmat[0] %}
 {%- endif %}
-{%- set hour_phrase = hour(this_hour, language=language) %}
-{%- set minute_phrase = _phrase('minute', 60 * this_minute, language, True, True) if this_minute % 5 else this_minute | string %}
-{%- if hour_phrase in ['noon', 'midnight'] and this_minute == 0 %}
-   {%- set fmat = '{hour}' %}
-{%- endif %}
-{{- fmat.format(hour=hour_phrase, minute=minute_phrase) -}}
+{{- fmat.format(hour=hour_phrase, this_hour=this_hour_phrase, next_hour=next_hour_phrase, minute=minute_phrase, this_minute=this_minute_phrase, minute_to_60=minute_to_60_phrase, minute_to_30=minute_to_30_phrase) -}}
 {%- endmacro %}

--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -236,8 +236,8 @@
       59: '1 voor {next_hour}',
       'past_hour': '{this_minute} over {hour}',
       'to_hour': '{minute_to_60} voor {next_hour}', 
-      'past_halfhour': '{minute_to_30} over half {next_hour}',
-      'to_halfhour': '{minute_to_30} voor half {next_hour}', 
+      'past_half_hour': '{minute_to_30} over half {next_hour}',
+      'to_half_hour': '{minute_to_30} voor half {next_hour}', 
       'format': '12-hr',
   
     },
@@ -1775,12 +1775,12 @@
 {%- elif this_minute > 30 %}
   {%- set fmat = translate('time_of_hour', 'to_hour', language=language) %}
   {%- if this_minute < 45 %}
-    {%- set fmat = translate('time_of_hour', 'past_halfhour', fallback=fmat,  language=language) %}
+    {%- set fmat = translate('time_of_hour', 'past_half_hour', fallback=fmat,  language=language) %}
   {%- endif %}
 {%- else %}
   {%- set fmat = translate('time_of_hour', 'past_hour', language=language) %}
   {%- if this_minute > 15 %}
-    {%- set fmat = translate('time_of_hour', 'to_halfhour', fallback=fmat,  language=language) %}
+    {%- set fmat = translate('time_of_hour', 'to_half_hour', fallback=fmat,  language=language) %}
   {%- endif %}
 {%- endif %}
 {{- fmat.format(hour=hour_phrase, this_hour=this_hour_phrase, next_hour=next_hour_phrase, minute=minute_phrase, this_minute=this_minute_phrase, minute_to_60=minute_to_60_phrase, minute_to_30=minute_to_30_phrase) -}}


### PR DESCRIPTION
The clock_phrase macro is a very welcome macro, for using with my TTS scripts and automations.

Sadly however the way how for example the dutch say the time is different then the English speakers.

This PR makes it more versatile to setup the right sentences a specific language.

To modify the *hour* or *minute*, the sentences niets to put in a list with maximal 3 variable:
- sentences
- the hour changes
- the minutes changes

I added 3 new optional mappings:
- 'past_half_hour': this will be used when minutes is between 30 and 45; when exist other wish it will use the `to_hour` mapping.
- 'to_half_hour': this will be used when minutes is between 15 and 30; when exist other wish it will use the `past_hour` mapping.
- 'past_12_hour': This can be used to modify the hour when it is after 12 o'clock. this mapping needs only a number. Usually -12 when used.

All the mappings except the `past_hour` is now optional. This allows for a very compact setup like:

```
    'time_of_hour':{
      'past_hour': '{hour} uur {minute}',
    },

```

The following mapping is for the 'en'
```
    'time_of_hour':{
      0: '{hour} o\'clock',
      1: 'a minute past {hour}',
      15: 'quarter past {hour}',
      30: 'half past {hour}',
      45: ['quarter to {hour}', +1],
      59: ['a minute to {hour}', +1, -60],
      'past_hour': '{minute} past {hour}',
      'to_hour': ['{minute} to {hour}', +1, -60],
    },
```
or for dutch:
```
    'time_of_hour':{
      0: 'klokslag {hour} uur',
      15: 'kwart over {hour}',
      30: ['half {hour}', 1],
      45: ['kwart voor {hour}', 1],
      'past_hour': '{minute} na {hour}',
      'to_hour': ['{minute} voor {hour}', 1, -30], 
      'past_half_hour': ['{minute} na half {hour}', 1, -30],
      'to_half_hour': ['{minute} voor half {hour}', 1, -30], 
      'past_12_hour': -12,
    },
```

