### PR TITLE
Add nearest_day(weekday) macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,14 +543,14 @@ day | number
 31st | 31
 </td></tr> </table>
 
-## `this_weekday(weekday)`, `last_weekday(weekday)`, `next_weekday(weekday)`
+## `this_weekday(weekday)`, `last_weekday(weekday)`, `next_weekday(weekday)`, `nearest_day(weekday)`
 
 Get the day of the week, in the future or past.
 
 ### Examples
 
 ```jinja
-{% from 'easy_time.jinja' import this_weekday, last_weekday, next_weekday %}
+{% from 'easy_time.jinja' import this_weekday, last_weekday, next_weekday, nearest_day %}
 
 {# Get Tuesdays date, this week #}
 {{ this_weekday(2) | as_datetime }}
@@ -560,6 +560,9 @@ Get the day of the week, in the future or past.
 
 {# Get last Tuesdays date #}
 {{ last_weekday(2) | as_datetime}}
+
+{# Get next Tuesdays date #}
+{{ nearest_day(2) | as_datetime}}
 ```
 
 ## `month_week_day(month, week, weekday)`

--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -1516,6 +1516,16 @@
 {{- _next_weekday(weekday, -7) }}
 {%- endmacro %}
 
+{%- macro nearest_day(weekday) %}
+{%- set today_timestamp = as_timestamp(today_at())|int %}
+{%- set this_weekday_timestamp = as_timestamp(this_weekday(weekday))|int %}
+{%- if today_timestamp <  this_weekday_timestamp %}
+  {{- _next_weekday(weekday, 0) }}
+{%- else %}
+  {{- _next_weekday(weekday, 7) }}
+{%- endif %}
+{%- endmacro %}
+
 {%- macro days_in_month(month=None) %}
 {%- set today = today_at() %}
 {%- set input = month if month is not none else today.month %}


### PR DESCRIPTION
This macro finds the next nearest day of the week.
For example, if today is Tuesday, 03/12, `nearest_day(2)` will return 10/12, and `nearest_day(3)` will return 04/12.