### PR TITLE
update swedish translation

### DIFF
--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -248,7 +248,7 @@
   'sv':{
     '_language': 'Svenska',
     'and': 'och',
-    'in': 'i',
+    'in': 'om',
     'ago': 'sedan',
     'now': 'nu',
     'lose': 'förlora',

--- a/easy_time.jinja
+++ b/easy_time.jinja
@@ -290,6 +290,7 @@
       'today': 'idag',
       'tomorrow': 'imorgon',
       'yesterday': 'igår',
+      'next': 'nästa',
     },
     'days':[
       "måndag",


### PR DESCRIPTION
```yaml
{% from 'easy_time.jinja' import easy_relative_time %}
{{ easy_relative_time("2026-01-01 00:00:00", language='sv') }}
```

should return "om" not "i"